### PR TITLE
Add overload functions to create LMem <-> Kernel interface

### DIFF
--- a/src/com/custom_computing_ic/dfe_snippets/manager/ManagerUtils.java
+++ b/src/com/custom_computing_ic/dfe_snippets/manager/ManagerUtils.java
@@ -168,6 +168,12 @@ public class ManagerUtils {
         LMemCommandGroup.MemoryAccessPattern.LINEAR_1D);
   }
 
+  public static void addLinearStreamFromLMemToKernel(LMemInterface iface, KernelBlock kernel, String src, String dst) {
+    kernel.getInput(dst) <== iface.addStreamFromLMem(
+        src,
+        LMemCommandGroup.MemoryAccessPattern.LINEAR_1D);
+  }
+
   @Deprecated
   public static void addLinearStreamFromKernelToLmem(CustomManager m, KernelBlock kernel, String name) {
     m.addStreamToOnCardMemory(
@@ -179,6 +185,12 @@ public class ManagerUtils {
     iface.addStreamToLMem(
         name,
         LMemCommandGroup.MemoryAccessPattern.LINEAR_1D) <== kernel.getOutput(name);
+  }
+
+  public static void addLinearStreamFromKernelToLMem(LMemInterface iface, KernelBlock kernel, String src, String dst) {
+    iface.addStreamToLMem(
+        dst,
+        LMemCommandGroup.MemoryAccessPattern.LINEAR_1D) <== kernel.getOutput(src);
   }
 
   public static void ignoreLMemStreams(EngineInterface ei) {

--- a/src/com/custom_computing_ic/dfe_snippets/manager/ManagerUtils.java
+++ b/src/com/custom_computing_ic/dfe_snippets/manager/ManagerUtils.java
@@ -168,6 +168,10 @@ public class ManagerUtils {
         LMemCommandGroup.MemoryAccessPattern.LINEAR_1D);
   }
 
+  public static void addLinearStreamFromLMemToKernel(LMemCommandGroup group, KernelBlock kernel, String name) {
+    kernel.getInput(name) <== group.addStreamFromLMem(name);
+  }
+
   public static void addLinearStreamFromLMemToKernel(LMemInterface iface, KernelBlock kernel, String src, String dst) {
     kernel.getInput(dst) <== iface.addStreamFromLMem(
         src,
@@ -185,6 +189,10 @@ public class ManagerUtils {
     iface.addStreamToLMem(
         name,
         LMemCommandGroup.MemoryAccessPattern.LINEAR_1D) <== kernel.getOutput(name);
+  }
+
+  public static void addLinearStreamFromKernelToLMem(LMemCommandGroup group, KernelBlock kernel, String name) {
+    group.addStreamToLMem(name) <== kernel.getOutput(name);
   }
 
   public static void addLinearStreamFromKernelToLMem(LMemInterface iface, KernelBlock kernel, String src, String dst) {


### PR DESCRIPTION
This PR creates two overloaded functions: 
```java
public static void addLinearStreamFromLMemToKernel(LMemInterface iface, KernelBlock kernel, String src, String dst);
public static void addLinearStreamFromKernelToLMem(LMemInterface iface, KernelBlock kernel, String src, String dst);
```

These two functions allow us to create LMem-Kernel interfaces to have different IO port names. Previously the LMem port should have the same name as the kernel's port which it's connecting to.